### PR TITLE
게시판 도메인 카테고리 추가

### DIFF
--- a/src/main/java/jeonseguard/backend/board/application/BoardFacade.java
+++ b/src/main/java/jeonseguard/backend/board/application/BoardFacade.java
@@ -16,13 +16,13 @@ public class BoardFacade {
     private final PostService postService;
     private final UserService userService;
 
-    public PostPageResponse getPosts(Pageable pageable) {
-        Page<Post> boards = postService.getPosts(pageable);
+    public PostPageResponse getPosts(String category, Pageable pageable) {
+        Page<Post> boards = postService.getPosts(category, pageable);
         return PostPageResponse.of(boards);
     }
 
-    public PostInfoResponse getPost(Long postId) {
-        Post post = postService.getPost(postId);
+    public PostInfoResponse getPost(String category, Long postId) {
+        Post post = postService.getPost(category, postId);
         return PostInfoResponse.fromEntity(post);
     }
 
@@ -32,15 +32,15 @@ public class BoardFacade {
         return CreatePostResponse.fromEntity(post);
     }
 
-    public void updatePost(Long userId, Long postId, UpdatePostRequest request) {
+    public void updatePost(String category, Long userId, Long postId, UpdatePostRequest request) {
         User user = userService.getUser(userId);
-        Post post = postService.getPost(postId);
-        postService.updatePost(request, user, post);
+        Post post = postService.getPost(category, postId);
+        postService.updatePost(user, post, request);
     }
 
-    public void deletePost(Long userId, Long postId) {
+    public void deletePost(String category, Long userId, Long postId) {
         User user = userService.getUser(userId);
-        Post post = postService.getPost(postId);
+        Post post = postService.getPost(category, postId);
         postService.deletePost(user, post);
     }
 }

--- a/src/main/java/jeonseguard/backend/board/application/BoardFacade.java
+++ b/src/main/java/jeonseguard/backend/board/application/BoardFacade.java
@@ -26,9 +26,9 @@ public class BoardFacade {
         return PostInfoResponse.fromEntity(post);
     }
 
-    public CreatePostResponse createPost(Long userId, CreatePostRequest request) {
+    public CreatePostResponse createPost(String category, Long userId, CreatePostRequest request) {
         User user = userService.getUser(userId);
-        Post post = postService.createPost(request, user);
+        Post post = postService.createPost(category, user, request);
         return CreatePostResponse.fromEntity(post);
     }
 

--- a/src/main/java/jeonseguard/backend/board/domain/entity/BoardCategory.java
+++ b/src/main/java/jeonseguard/backend/board/domain/entity/BoardCategory.java
@@ -1,0 +1,6 @@
+package jeonseguard.backend.board.domain.entity;
+
+public enum BoardCategory {
+    PREVENTION,
+    REPORT
+}

--- a/src/main/java/jeonseguard/backend/board/domain/entity/Post.java
+++ b/src/main/java/jeonseguard/backend/board/domain/entity/Post.java
@@ -18,6 +18,10 @@ public class Post extends CommonBaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BoardCategory category;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @JsonBackReference

--- a/src/main/java/jeonseguard/backend/board/domain/entity/Post.java
+++ b/src/main/java/jeonseguard/backend/board/domain/entity/Post.java
@@ -40,13 +40,13 @@ public class Post extends CommonBaseEntity {
     }
 
     private void updatePostTitle(String title) {
-        if (title != null) {
+        if (title != null && !title.isBlank()) {
             this.title = title;
         }
     }
 
     private void updatePostContent(String content) {
-        if (content != null) {
+        if (content != null && !content.isBlank()) {
             this.content = content;
         }
     }

--- a/src/main/java/jeonseguard/backend/board/domain/factory/PostFactory.java
+++ b/src/main/java/jeonseguard/backend/board/domain/factory/PostFactory.java
@@ -1,15 +1,16 @@
 package jeonseguard.backend.board.domain.factory;
 
-import jeonseguard.backend.board.domain.entity.Post;
+import jeonseguard.backend.board.domain.entity.*;
 import jeonseguard.backend.board.presentation.dto.request.CreatePostRequest;
 import jeonseguard.backend.user.domain.entity.User;
 
 public class PostFactory {
-    public static Post fromRequest(CreatePostRequest request, User user) {
+    public static Post fromRequest(BoardCategory category, User user, CreatePostRequest request) {
         return Post.builder()
                 .title(request.title())
                 .content(request.content())
                 .user(user)
+                .category(category)
                 .createdBy(user.getNickname())
                 .updatedBy(user.getNickname())
                 .build();

--- a/src/main/java/jeonseguard/backend/board/domain/repository/PostRepository.java
+++ b/src/main/java/jeonseguard/backend/board/domain/repository/PostRepository.java
@@ -1,13 +1,13 @@
 package jeonseguard.backend.board.domain.repository;
 
-import jeonseguard.backend.board.domain.entity.Post;
+import jeonseguard.backend.board.domain.entity.*;
 import org.springframework.data.domain.*;
 
 import java.util.Optional;
 
 public interface PostRepository {
-    Optional<Post> findById(Long id);
-    Page<Post> findAll(Pageable pageable);
+    Page<Post> findAllByCategory(BoardCategory category, Pageable pageable);
+    Optional<Post> findByCategoryAndId(BoardCategory category, Long id);
     Post save(Post post);
     void delete(Post post);
 }

--- a/src/main/java/jeonseguard/backend/board/domain/service/PostService.java
+++ b/src/main/java/jeonseguard/backend/board/domain/service/PostService.java
@@ -1,7 +1,6 @@
 package jeonseguard.backend.board.domain.service;
 
-import jeonseguard.backend.board.domain.entity.BoardCategory;
-import jeonseguard.backend.board.domain.entity.Post;
+import jeonseguard.backend.board.domain.entity.*;
 import jeonseguard.backend.board.domain.factory.PostFactory;
 import jeonseguard.backend.board.domain.repository.PostRepository;
 import jeonseguard.backend.board.presentation.dto.request.*;
@@ -18,13 +17,13 @@ public class PostService {
     private final PostRepository postRepository;
 
     @Transactional(readOnly = true)
-    public Page<Post> getPosts(Pageable pageable) {
-        return postRepository.findAll(pageable);
+    public Page<Post> getPosts(String category, Pageable pageable) {
+        return postRepository.findAllByCategory(parseCategory(category), pageable);
     }
 
     @Transactional(readOnly = true)
-    public Post getPost(Long postId) {
-        return postRepository.findById(postId)
+    public Post getPost(String category, Long postId) {
+        return postRepository.findByCategoryAndId(parseCategory(category), postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
     }
 
@@ -35,7 +34,7 @@ public class PostService {
     }
 
     @Transactional
-    public void updatePost(UpdatePostRequest request, User user, Post post) {
+    public void updatePost(User user, Post post, UpdatePostRequest request) {
         validateAuthor(user, post, ErrorCode.POST_UPDATE_FORBIDDEN);
         post.updatePost(request.newTitle(), request.newContent(), user.getNickname());
     }

--- a/src/main/java/jeonseguard/backend/board/domain/service/PostService.java
+++ b/src/main/java/jeonseguard/backend/board/domain/service/PostService.java
@@ -1,5 +1,6 @@
 package jeonseguard.backend.board.domain.service;
 
+import jeonseguard.backend.board.domain.entity.BoardCategory;
 import jeonseguard.backend.board.domain.entity.Post;
 import jeonseguard.backend.board.domain.factory.PostFactory;
 import jeonseguard.backend.board.domain.repository.PostRepository;
@@ -28,8 +29,8 @@ public class PostService {
     }
 
     @Transactional
-    public Post createPost(CreatePostRequest request, User user) {
-        Post post = PostFactory.fromRequest(request, user);
+    public Post createPost(String category, User user, CreatePostRequest request) {
+        Post post = PostFactory.fromRequest(parseCategory(category), user, request);
         return postRepository.save(post);
     }
 
@@ -49,5 +50,9 @@ public class PostService {
         if (!post.getUser().getId().equals(user.getId())) {
             throw new BusinessException(errorCode);
         }
+    }
+
+    private BoardCategory parseCategory(String category) {
+        return BoardCategory.valueOf(category.toUpperCase());
     }
 }

--- a/src/main/java/jeonseguard/backend/board/infrastructure/PostJpaRepository.java
+++ b/src/main/java/jeonseguard/backend/board/infrastructure/PostJpaRepository.java
@@ -1,7 +1,12 @@
 package jeonseguard.backend.board.infrastructure;
 
-import jeonseguard.backend.board.domain.entity.Post;
+import jeonseguard.backend.board.domain.entity.*;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAllByCategory(BoardCategory category, Pageable pageable);
+    Optional<Post> findByCategoryAndId(BoardCategory category, Long id);
 }

--- a/src/main/java/jeonseguard/backend/board/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/jeonseguard/backend/board/infrastructure/PostRepositoryImpl.java
@@ -1,5 +1,6 @@
 package jeonseguard.backend.board.infrastructure;
 
+import jeonseguard.backend.board.domain.entity.BoardCategory;
 import jeonseguard.backend.board.domain.entity.Post;
 import jeonseguard.backend.board.domain.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +15,13 @@ public class PostRepositoryImpl implements PostRepository {
     private final PostJpaRepository jpaRepository;
 
     @Override
-    public Optional<Post> findById(Long id) {
-        return jpaRepository.findById(id);
+    public Page<Post> findAllByCategory(BoardCategory category, Pageable pageable) {
+        return jpaRepository.findAllByCategory(category, pageable);
     }
 
     @Override
-    public Page<Post> findAll(Pageable pageable) {
-        return jpaRepository.findAll(pageable);
+    public Optional<Post> findByCategoryAndId(BoardCategory category, Long id) {
+        return jpaRepository.findByCategoryAndId(category, id);
     }
 
     @Override

--- a/src/main/java/jeonseguard/backend/board/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/jeonseguard/backend/board/infrastructure/PostRepositoryImpl.java
@@ -1,7 +1,6 @@
 package jeonseguard.backend.board.infrastructure;
 
-import jeonseguard.backend.board.domain.entity.BoardCategory;
-import jeonseguard.backend.board.domain.entity.Post;
+import jeonseguard.backend.board.domain.entity.*;
 import jeonseguard.backend.board.domain.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;

--- a/src/main/java/jeonseguard/backend/board/presentation/controller/BoardController.java
+++ b/src/main/java/jeonseguard/backend/board/presentation/controller/BoardController.java
@@ -15,38 +15,47 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Board", description = "게시판 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/board")
+@RequestMapping("/api/v1/board/{category}")
 public class BoardController {
     private final BoardFacade boardFacade;
 
     @Operation(summary = "게시글 전체 조회", description = "모든 게시글을 페이지네이션과 함깨 조회합니다.")
     @GetMapping
-    public ResponseEntity<PostPageResponse> getPosts(Pageable pageable) {
+    public ResponseEntity<PostPageResponse> getPosts(@PathVariable String category,
+                                                     Pageable pageable) {
         return ResponseEntity.ok(boardFacade.getPosts(pageable));
     }
 
     @Operation(summary = "게시글 상세 조회", description = "게시글 ID를 이용하여, 특정 게시글을 조회합니다.")
     @GetMapping("/{postId}")
-    public ResponseEntity<PostInfoResponse> getPost(@PathVariable Long postId) {
+    public ResponseEntity<PostInfoResponse> getPost(@PathVariable String category,
+                                                    @PathVariable Long postId) {
         return ResponseEntity.ok(boardFacade.getPost(postId));
     }
 
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     @PostMapping
-    public ResponseEntity<CreatePostResponse> createPost(@AuthenticatedUser Long userId, @Valid @RequestBody CreatePostRequest request) {
-        return ResponseEntity.ok(boardFacade.createPost(userId, request));
+    public ResponseEntity<CreatePostResponse> createPost(@PathVariable String category,
+                                                         @AuthenticatedUser Long userId,
+                                                         @Valid @RequestBody CreatePostRequest request) {
+        return ResponseEntity.ok(boardFacade.createPost(category, userId, request));
     }
 
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
     @PatchMapping("/{postId}")
-    public ResponseEntity<Void> updatePost(@AuthenticatedUser Long userId, @PathVariable Long postId, @RequestBody UpdatePostRequest request) {
+    public ResponseEntity<Void> updatePost(@PathVariable String category,
+                                           @AuthenticatedUser Long userId,
+                                           @PathVariable Long postId,
+                                           @RequestBody UpdatePostRequest request) {
         boardFacade.updatePost(userId, postId, request);
         return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@AuthenticatedUser Long userId, @PathVariable Long postId) {
+    public ResponseEntity<Void> deletePost(@PathVariable String category,
+                                           @AuthenticatedUser Long userId,
+                                           @PathVariable Long postId) {
         boardFacade.deletePost(userId, postId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/jeonseguard/backend/board/presentation/controller/BoardController.java
+++ b/src/main/java/jeonseguard/backend/board/presentation/controller/BoardController.java
@@ -23,14 +23,14 @@ public class BoardController {
     @GetMapping
     public ResponseEntity<PostPageResponse> getPosts(@PathVariable String category,
                                                      Pageable pageable) {
-        return ResponseEntity.ok(boardFacade.getPosts(pageable));
+        return ResponseEntity.ok(boardFacade.getPosts(category, pageable));
     }
 
     @Operation(summary = "게시글 상세 조회", description = "게시글 ID를 이용하여, 특정 게시글을 조회합니다.")
     @GetMapping("/{postId}")
     public ResponseEntity<PostInfoResponse> getPost(@PathVariable String category,
                                                     @PathVariable Long postId) {
-        return ResponseEntity.ok(boardFacade.getPost(postId));
+        return ResponseEntity.ok(boardFacade.getPost(category, postId));
     }
 
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
@@ -47,7 +47,7 @@ public class BoardController {
                                            @AuthenticatedUser Long userId,
                                            @PathVariable Long postId,
                                            @RequestBody UpdatePostRequest request) {
-        boardFacade.updatePost(userId, postId, request);
+        boardFacade.updatePost(category, userId, postId, request);
         return ResponseEntity.noContent().build();
     }
 
@@ -56,7 +56,7 @@ public class BoardController {
     public ResponseEntity<Void> deletePost(@PathVariable String category,
                                            @AuthenticatedUser Long userId,
                                            @PathVariable Long postId) {
-        boardFacade.deletePost(userId, postId);
+        boardFacade.deletePost(category, userId, postId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/jeonseguard/backend/board/presentation/dto/response/PostInfoResponse.java
+++ b/src/main/java/jeonseguard/backend/board/presentation/dto/response/PostInfoResponse.java
@@ -9,6 +9,7 @@ public record PostInfoResponse(
         @Schema(description = "게시글 ID") Long postId,
         @Schema(description = "제목") String title,
         @Schema(description = "내용") String content,
+        @Schema(description = "카테고리") String category,
         @Schema(description = "생성자") String creator,
         @Schema(description = "생성일") LocalDate createdAt
 ) {
@@ -17,6 +18,7 @@ public record PostInfoResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
+                post.getCategory().toString(),
                 post.getCreatedBy(),
                 post.getCreatedAt().toLocalDate()
         );


### PR DESCRIPTION
## 요약
1. 게시판 도메인 카테고리를 적용하여, 카테고리별 게시판 관리
2. PostRepository에 조회 메서드에 category 추가

## 내용
1. /api/v1/board -> /api/v1/board/{category} 수정
2. 게시판 도메인 카테고리를 적용하여, 예방 게시판 (PREVENTION)과 신고 게시판 (REPORT)을 분리해서 관리
3. Request URL (/api/v1/board/{category})에서 category를 추출해서 구분
4. PostRepository에 findAllByCategory 메서드 추가하여, 카테고리별 게시글 전체 조회
5. PostRepository에 findByCategoryAndId 메서드 추가하여, 카테고리별 게시글 상세 조회