### PR TITLE
PASSPHARSE 없는 SSH 배포 키 적용 및 자동 배포 안정화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: Deploy to GCP
+name: Deploy to GCP (Develop)
 
 on:
   push:
     branches:
-      - develop 
+      - develop
       - fix/ci-cd
 
 jobs:
@@ -30,15 +30,14 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:latest
 
-      - name: Install sshpass
-        run: sudo apt-get update && sudo apt-get install -y sshpass
+      - name: Setup SSH for GCP
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.GCP_SSH_KEY }}
 
-      - name: Deploy on GCP VM using sshpass
+      - name: Deploy on GCP VM
         run: |
-          echo "${{ secrets.GCP_SSH_KEY }}" > gcp_key.pem
-          chmod 600 gcp_key.pem
-
-          sshpass -p "${{ secrets.GCP_PASSPHRASE }}" ssh -o StrictHostKeyChecking=no -i gcp_key.pem ${{ secrets.GCP_USERNAME }}@${{ secrets.GCP_HOST }} << EOF
+          ssh -o StrictHostKeyChecking=no ${{ secrets.GCP_USERNAME }}@${{ secrets.GCP_HOST }} << EOF
             cd /home/${{ secrets.GCP_USERNAME }}
             docker compose down
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
-name: Deploy to GCP (Develop)
+name: Deploy to GCP
 
 on:
   push:
     branches:
-      - develop
+      - develop 
+      - fix/ci-cd
 
 jobs:
   deploy:
@@ -29,14 +30,15 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:latest
 
-      - name: Setup SSH for GCP
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.GCP_SSH_KEY }}
+      - name: Install sshpass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
 
-      - name: Deploy on GCP VM
+      - name: Deploy on GCP VM using sshpass
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.GCP_USERNAME }}@${{ secrets.GCP_HOST }} << EOF
+          echo "${{ secrets.GCP_SSH_KEY }}" > gcp_key.pem
+          chmod 600 gcp_key.pem
+
+          sshpass -p "${{ secrets.GCP_PASSPHRASE }}" ssh -o StrictHostKeyChecking=no -i gcp_key.pem ${{ secrets.GCP_USERNAME }}@${{ secrets.GCP_HOST }} << EOF
             cd /home/${{ secrets.GCP_USERNAME }}
             docker compose down
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}


### PR DESCRIPTION
## 요약
* GitHub Actions에서 SSH 자동 접속이 실패하던 문제를 해결하기 위해, passphrase 없는 배포 전용 SSH 키를 새로 생성하고 GCP에 등록
* 이를 통해 `sshpass` 없이도 안전하고 안정적인 자동 배포가 가능

## 내용
* `ssh-keygen`을 통해 passphrase 없는 배포용 SSH 키(`gcp_deploy_key`) 생성
* 해당 공개키를 GCP VM 메타데이터에 등록
* 개인키(`GCP_SSH_KEY`)를 GitHub Secrets에 등록
* 기존 `sshpass` 제거, 표준적인 `webfactory/ssh-agent` 방식으로 복원
* 배포 스크립트에서 `GCP_PASSPHRASE` 관련 의존성 제거

## 이슈
#58
