### PR TITLE
배포 서버 도메인(https://jeonseguard.duckdns.org)을 WebConfig CORS 허용 도메인에 추가

### DIFF
--- a/src/main/java/jeonseguard/backend/global/config/WebConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("http://localhost:3000", "https://jeonseguard.duckdns.org")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
## 이슈
#64
