### PR TITLE
Swagger 서버 스킴 https 설정 및 프론트엔드 배포 환경 CORS 도메인 추가

### DIFF
--- a/src/main/java/jeonseguard/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/SwaggerConfig.java
@@ -3,8 +3,11 @@ package jeonseguard.backend.global.config;
 import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.*;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.*;
 import org.springframework.http.HttpHeaders;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -12,6 +15,7 @@ public class SwaggerConfig {
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(apiInfo())
+                .servers(serverList())
                 .components(securityComponents())
                 .addSecurityItem(securityRequirements());
     }
@@ -56,5 +60,18 @@ public class SwaggerConfig {
                 .authorizationCode(new OAuthFlow()
                         .authorizationUrl("https://kauth.kakao.com/oauth/authorize")
                         .tokenUrl("https://kauth.kakao.com/oauth/token"));
+    }
+
+    private List<Server> serverList() {
+        return List.of(
+                createServer("https://jeonseguard.duckdns.org", "Production Server"),
+                createServer("http://localhost:8080", "Local Server")
+        );
+    }
+
+    private Server createServer(String url, String description) {
+        return new Server()
+                .url(url)
+                .description(description);
     }
 }

--- a/src/main/java/jeonseguard/backend/global/config/WebConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://jeonseguard.duckdns.org")
+                .allowedOrigins("https://jeonseguard.duckdns.org", "http://localhost:3000", "https://jeonse-guard-frontend.vercel.app")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
## 요약
배포 환경에서 Swagger UI 및 프론트엔드에서 API 요청 시 발생하던 CORS 오류를 해결하였습니다.

## 내용
* `WebConfig`의 CORS 설정에 배포 프론트엔드 도메인(`https://jeonseguard.duckdns.org`)을 추가
* `SwaggerConfig`에서 `.servers()`를 명시적으로 설정하여 기본 서버 URL 스킴을 `https`로 지정

## 이슈
#66 
#67 

## 참고자료
* [[swagger Failed to fetch 오류] 운영서버 URL scheme must be...](https://kwakscoding.tistory.com/49)
* [MDN CORS Docs](https://developer.mozilla.org/ko/docs/Web/HTTP/CORS)
