### PR TITLE
악성 요청 경로 차단 인터셉터 도입

### DIFF
--- a/src/main/java/jeonseguard/backend/global/config/CacheConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/CacheConfig.java
@@ -28,7 +28,6 @@ public class CacheConfig {
         cacheConfigs.put("board", defaultRedisCacheConfig);
         cacheConfigs.put("postDetail", createRedisCacheConfigWithTtl(serializer, 1));
         cacheConfigs.put("commentList", createRedisCacheConfigWithTtl(serializer, 1));
-//        cacheConfigs.put("userInfo", createRedisCacheConfigWithTtl(serializer, 30));
         cacheConfigs.put("userDetail", createRedisCacheConfigWithTtl(serializer, 30));
         cacheConfigs.put("regionDetail", createRedisCacheConfigWithTtl(serializer, 360));
         cacheConfigs.put("buildingRegister", createRedisCacheConfigWithTtl(serializer, 360));

--- a/src/main/java/jeonseguard/backend/global/config/WebConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package jeonseguard.backend.global.config;
 
 import jeonseguard.backend.auth.infrastructure.resolver.AuthenticatedUserArgumentResolver;
 import jeonseguard.backend.global.config.properties.*;
+import jeonseguard.backend.global.intercepter.MaliciousPathBlockInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,7 @@ import java.util.List;
 @EnableConfigurationProperties({JwtTokenProperties.class, TransactionProperties.class, MaliciousPathProperties.class})
 public class WebConfig implements WebMvcConfigurer {
     private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
+    private final MaliciousPathBlockInterceptor maliciousPathBlockInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -29,4 +31,12 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(maliciousPathBlockInterceptor)
+                .order(0)
+                .addPathPatterns("/**");
+    }
+
 }

--- a/src/main/java/jeonseguard/backend/global/config/WebConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/WebConfig.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableConfigurationProperties({JwtTokenProperties.class, TransactionProperties.class})
+@EnableConfigurationProperties({JwtTokenProperties.class, TransactionProperties.class, MaliciousPathProperties.class})
 public class WebConfig implements WebMvcConfigurer {
     private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
 

--- a/src/main/java/jeonseguard/backend/global/config/WebConfig.java
+++ b/src/main/java/jeonseguard/backend/global/config/WebConfig.java
@@ -38,5 +38,4 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(0)
                 .addPathPatterns("/**");
     }
-
 }

--- a/src/main/java/jeonseguard/backend/global/config/properties/MaliciousPathProperties.java
+++ b/src/main/java/jeonseguard/backend/global/config/properties/MaliciousPathProperties.java
@@ -1,0 +1,11 @@
+package jeonseguard.backend.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "malicious")
+public record MaliciousPathProperties(
+        List<String> blockedPathPrefixes
+) {
+}

--- a/src/main/java/jeonseguard/backend/global/intercepter/MaliciousPathBlockInterceptor.java
+++ b/src/main/java/jeonseguard/backend/global/intercepter/MaliciousPathBlockInterceptor.java
@@ -1,23 +1,31 @@
 package jeonseguard.backend.global.intercepter;
 
 import jakarta.servlet.http.*;
+import jeonseguard.backend.global.config.properties.MaliciousPathProperties;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
+@RequiredArgsConstructor
 public class MaliciousPathBlockInterceptor implements HandlerInterceptor {
-    private static final String BLOCKED_PATH_PREFIX = "/goform";
+    private final MaliciousPathProperties properties;
 
     @Override
     public boolean preHandle(@NonNull HttpServletRequest request,
                              @NonNull HttpServletResponse response,
                              @NonNull Object handler) {
         String path = request.getRequestURI();
-        return !path.startsWith(BLOCKED_PATH_PREFIX) || blockAccess(response);
+        return isNotBlockedPath(path) || handleBlockedPath(response);
     }
 
-    private boolean blockAccess(HttpServletResponse response) {
+    private boolean isNotBlockedPath(String path) {
+        return properties.blockedPathPrefixes().stream()
+                .noneMatch(path::startsWith);
+    }
+
+    private boolean handleBlockedPath(HttpServletResponse response) {
         response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         return false;
     }

--- a/src/main/java/jeonseguard/backend/global/intercepter/MaliciousPathBlockInterceptor.java
+++ b/src/main/java/jeonseguard/backend/global/intercepter/MaliciousPathBlockInterceptor.java
@@ -1,0 +1,24 @@
+package jeonseguard.backend.global.intercepter;
+
+import jakarta.servlet.http.*;
+import lombok.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class MaliciousPathBlockInterceptor implements HandlerInterceptor {
+    private static final String BLOCKED_PATH_PREFIX = "/goform";
+
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) {
+        String path = request.getRequestURI();
+        return !path.startsWith(BLOCKED_PATH_PREFIX) || blockAccess(response);
+    }
+
+    private boolean blockAccess(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        return false;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: false
         use_sql_comments: true
+    open-in-view: false
 
   flyway:
     enabled: true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -79,6 +79,9 @@ openapi:
 transaction:
   contract-year-months: ${TRANSACTION_CONTRACT_YEAR_MONTHS}
 
+malicious:
+  blocked-path-prefixes: ${MALICIOUS_BLOCKED_PATH_PREFIXES}
+
 logging:
   level:
     org.hibernate.sql: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: false
         use_sql_comments: true
+    open-in-view: false
 
   flyway:
     enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -79,6 +79,9 @@ openapi:
 transaction:
   contract-year-months: ${TRANSACTION_CONTRACT_YEAR_MONTHS}
 
+malicious:
+  blocked-path-prefixes: ${MALICIOUS_BLOCKED_PATH_PREFIXES}
+
 logging:
   level:
     org.hibernate.sql: debug


### PR DESCRIPTION
## 요약
* 비정상적이고 악의적인 경로(`/goform/`** 등) 요청에 대해 404 응답으로 차단하는 `MaliciousPathBlockInterceptor`를 도입
* 운영/개발 환경에 따라 차단 경로를 유연하게 관리할 수 있도록 `MaliciousPathProperties` 및 환경 변수 설정을 함께 구성

## 내용
* MaliciousPathBlockInterceptor 구현
* MaliciousPathProperties 구현 및 환경 변수 바인딩 처리
* application-local.yml, application-dev.yml에 malicious.blocked-path-prefixes 값 설정
* WebConfig: 인터셉터 등록 및 @EnableConfigurationProperties로 연동

## 이슈
#92 

## 참고자료
- [Spring 공식 문서 - WebMvcConfigurer](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config.html)
- [Tomcat HTTP method invalid character 대응 로그](https://stackoverflow.com/questions/9559674/dp-algorithm-for-bounded-knapsack/55560105#55560105)
