### PR TITLE
Docker 환경 CGroup 이슈로 메트릭 자동 구성 제외

### DIFF
--- a/src/main/java/jeonseguard/backend/JeonseGuardBackendApplication.java
+++ b/src/main/java/jeonseguard/backend/JeonseGuardBackendApplication.java
@@ -4,7 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(exclude = {
-		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class
+		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class,
+		org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration.class
 })
 public class JeonseGuardBackendApplication {
 


### PR DESCRIPTION
```
Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
2025-05-31T01:21:09.328+09:00 ERROR 1 --- [jeonseguard] [           main] o.s.boot.SpringApplication               : Application run failed

java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81) ~[na:na]
	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113) ~[na:na]
	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167) ~[na:na]
	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29) ~[na:na]
	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58) ~[na:na]
	at java.base/jdk.internal.platform.Container.metrics(Container.java:43) ~[na:na]
	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182) ~[na:na]
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280) ~[na:na]
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199) ~[na:na]
	at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(ManagementFactory.java:488) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) ~[na:na]
	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1779) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[na:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[na:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[na:na]
	at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(ManagementFactory.java:489) ~[na:na]
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetrics.getMBeanServer(TomcatMetrics.java:98) ~[micrometer-core-1.14.4.jar!/:1.14.4]
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetrics.<init>(TomcatMetrics.java:72) ~[micrometer-core-1.14.4.jar!/:1.14.4]
	at org.springframework.boot.actuate.metrics.web.tomcat.TomcatMetricsBinder.onApplicationEvent(TomcatMetricsBinder.java:63) ~[spring-boot-actuator-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.actuate.metrics.web.tomcat.TomcatMetricsBinder.onApplicationEvent(TomcatMetricsBinder.java:42) ~[spring-boot-actuator-3.4.3.jar!/:3.4.3]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:185) ~[spring-context-6.2.3.jar!/:6.2.3]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:178) ~[spring-context-6.2.3.jar!/:6.2.3]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:156) ~[spring-context-6.2.3.jar!/:6.2.3]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:454) ~[spring-context-6.2.3.jar!/:6.2.3]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:387) ~[spring-context-6.2.3.jar!/:6.2.3]
	at org.springframework.boot.context.event.EventPublishingRunListener.started(EventPublishingRunListener.java:103) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.SpringApplicationRunListeners.lambda$started$5(SpringApplicationRunListeners.java:76) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at java.base/java.lang.Iterable.forEach(Iterable.java:75) ~[na:na]
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:118) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:112) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.SpringApplicationRunListeners.started(SpringApplicationRunListeners.java:76) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:324) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) ~[spring-boot-3.4.3.jar!/:3.4.3]
	at jeonseguard.backend.JeonseGuardBackendApplication.main(JeonseGuardBackendApplication.java:12) ~[!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102) ~[app.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64) ~[app.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40) ~[app.jar:0.0.1-SNAPSHOT]
```